### PR TITLE
созданы стили для компонента Аккордеон

### DIFF
--- a/03-lection1/02-accordion/accordion.css
+++ b/03-lection1/02-accordion/accordion.css
@@ -1,1 +1,51 @@
 /* Стилизация аккордеона */
+.accordion {
+    box-sizing: border-box;
+    left: 10px;
+    top: 10px;
+    width: 579px;
+    padding: 15px;
+    border: 1px solid var(--grey-3);
+    background-color: var(--white);
+    border-radius: 8px;
+    margin-bottom: 8px;
+    position: relative;
+}
+
+.accordion:last-child {
+    margin-bottom: 0px;
+}
+
+.accordion__summary {
+    display: block;
+    font-size: 16px;
+    font-weight: normal;
+    font-family: Inter, sans-serif;
+    color: var(--black);
+}
+
+.accordion__summary:hover {
+    cursor: pointer;
+}
+
+.accordion[open] .accordion__summary {
+    font-weight: bolder;
+}
+
+.accordion__summary::-webkit-details-marker {
+/* 
+    Для поддержки Chrome версий 88 и ниже. C 89 версии summary имеет display: list-item по-умолчанию.
+    Стандартный маркер убирается путем изменения display: list-item на display: block
+*/
+    display: none
+}
+
+.accordion__detail {
+    display: block;
+    font-size: 16px;
+    font-weight: normal;
+    font-family: Inter, sans-serif;
+    color: var(--grey-4);
+    margin-bottom: 0px;
+    text-align: justify;
+}

--- a/03-lection1/02-accordion/accordion.css
+++ b/03-lection1/02-accordion/accordion.css
@@ -1,18 +1,21 @@
 /* Стилизация аккордеона */
 .accordion {
-    box-sizing: border-box;
-    left: 10px;
-    top: 10px;
     width: 579px;
     padding: 15px;
     border: 1px solid var(--grey-3);
     background-color: var(--white);
     border-radius: 8px;
-    margin-bottom: 8px;
-    position: relative;
 }
 
-.accordion:last-child {
+.accordion__item {
+    /* position: relative;
+    left: 10px;
+    top: 10px;*/
+    margin-bottom: 8px;
+    box-sizing: border-box;
+}
+
+.accordion__item:last-child {
     margin-bottom: 0px;
 }
 

--- a/03-lection1/02-accordion/index.html
+++ b/03-lection1/02-accordion/index.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="./accordion.css">
     </head>
     <body>
-        <details class="accordion">
+        <details class="accordion accordion__item">
             <summary class="accordion__summary">
                 HTML
             </summary>
@@ -15,7 +15,7 @@
                 HTML (от англ. HyperText Markup Language — «язык гипертекстовой разметки») — стандартизированный язык разметки документов для просмотра веб-страниц в браузере.
             </p>
         </details>
-        <details class="accordion">
+        <details class="accordion accordion__item">
             <summary class="accordion__summary">
                 CSS
             </summary>

--- a/03-lection1/02-accordion/index.html
+++ b/03-lection1/02-accordion/index.html
@@ -2,16 +2,25 @@
 <!-- Страница с аккордеоном -->
 <html lang="ru">
     <head>
+        <link rel="stylesheet" href="../../assets/css/normalize.css">
         <link rel="stylesheet" href="../../assets/css/main.css">
         <link rel="stylesheet" href="./accordion.css">
     </head>
     <body>
-        <details>
-            <summary>
-                Accordion item
+        <details class="accordion">
+            <summary class="accordion__summary">
+                HTML
             </summary>
-            <p>
-                Hidden content
+            <p class="accordion__detail">
+                HTML (от англ. HyperText Markup Language — «язык гипертекстовой разметки») — стандартизированный язык разметки документов для просмотра веб-страниц в браузере.
+            </p>
+        </details>
+        <details class="accordion">
+            <summary class="accordion__summary">
+                CSS
+            </summary>
+            <p class="accordion__detail">
+                CSS (/siːɛsɛs/ англ. Cascading Style Sheets «каскадные таблицы стилей») — формальный язык описания внешнего вида документа (веб-страницы), написанного с использованием языка разметки (чаще всего HTML или XHTML).
             </p>
         </details>
     </body>


### PR DESCRIPTION
задание выполнено. в процессе выполнения выяснилось, что ::-webkit-details-marker с версии 89 Chrome не поддерживается и для summary устанавливается свойство display: list-item. Маркер убирается путем изменения свойства на display: block.